### PR TITLE
DM-38210: Use butler.get() rather than deprecated getDirect()

### DIFF
--- a/python/lsst/summit/extras/logUtils.py
+++ b/python/lsst/summit/extras/logUtils.py
@@ -100,7 +100,7 @@ class LogBrowser:
         for i, dataRef in enumerate(dataRefs):
             if (i+1) % 100 == 0:
                 self.log.info(f"Loaded {i+1} logs...")
-            log = self.butler.getDirect(dataRef)
+            log = self.butler.get(dataRef)
             logs[dataRef] = log
         return logs
 


### PR DESCRIPTION
Requires lsst/daf_butler#797