### PR TITLE
DM-54789: Add Codecov and mypy-coverage

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -51,3 +51,9 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
+          # Explicit slug so Codecov's repo lookup doesn't rely on
+          # auto-detection from the git remote, which has been a source
+          # of "Repository not found" 404s after the lsst-sitcom ->
+          # lsst-so org rename. ``github.repository`` resolves to the
+          # org/repo of the currently running workflow.
+          slug: ${{ github.repository }}

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -1,0 +1,53 @@
+name: "codecov"
+
+# Runs the test suite under the LSST science pipelines stack and uploads
+# the coverage report to Codecov on every PR and on pushes to main.
+# Pinned to the moving ``w_latest`` stack tag so the job tracks the
+# current weekly without requiring manual bumps.
+
+"on":
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    name: "Run pytest with coverage"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    container:
+      image: ghcr.io/lsst/scipipe:al9-w_latest
+      options: --user root
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Set up package and run pytest with coverage"
+        shell: bash -l {0}
+        run: |
+          source /opt/lsst/software/stack/loadLSST.bash
+          setup lsst_sitcom
+          pip install pytest pytest-cov
+          eups declare -r . -t current summit_extras git
+          setup -t current summit_extras
+          scons --no-tests
+          pytest \
+            --cov=lsst.summit.extras \
+            --cov-report=xml \
+            --cov-report=term \
+            tests/
+
+      - name: "Upload coverage to Codecov"
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/mypy-coverage.yaml
+++ b/.github/workflows/mypy-coverage.yaml
@@ -1,0 +1,74 @@
+name: "mypy coverage"
+
+# Runs https://github.com/mfisherlevine/mypy_coverage on every PR and on
+# pushes to main. Currently informational only (no threshold), so it can
+# never block a merge -- the value is the inline annotations on the PR
+# diff for unannotated / partially annotated definitions, plus the
+# markdown coverage report posted as a sticky PR comment.
+#
+# To gate on a coverage floor in the future, add ``threshold: 85`` (or
+# whatever) under ``with:`` and add the job's name to the required
+# status checks for ``main`` in the branch protection settings.
+
+"on":
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    name: "Annotate coverage gaps"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - id: mc
+        uses: mfisherlevine/mypy_coverage@v0.2.3
+        with:
+          version: "0.2.3"
+          format: github
+          # Use the repo's mypy.ini directly so we pick up the same
+          # exclude pattern, files=, and mypy_path= as the local mypy run.
+          config: mypy.ini
+          # Drop the walled-off "Excluded files" section: it's noise in
+          # the PR comment and reviewers don't act on it.
+          include-excluded: "false"
+      - name: "Build markdown report"
+        if: always()
+        # The action above pip-installs mypy-coverage, so the CLI is on
+        # PATH for the rest of the job. Re-run it here in markdown mode
+        # to produce a body we can post as a sticky PR comment.
+        run: |
+          mypy-coverage \
+            --color never \
+            --format markdown \
+            --no-include-excluded \
+            --config mypy.ini \
+            > "$RUNNER_TEMP/mypy-coverage.md" \
+            || true
+      - name: "Coverage summary"
+        if: always()
+        run: cat "$RUNNER_TEMP/mypy-coverage.md" >> "$GITHUB_STEP_SUMMARY"
+      - name: "Post sticky PR comment (recreated each run)"
+        # ``recreate: true`` deletes the previous comment and posts a
+        # fresh one each run, so the new comment gets a current
+        # timestamp and the PR conversation always renders it at the
+        # bottom (after every commit) instead of stranded at the top
+        # where it first appeared.
+        if: always() && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: mypy-coverage-report
+          recreate: true
+          path: ${{ runner.temp }}/mypy-coverage.md

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: false
+  # Delete and re-create the comment on every push instead of editing
+  # in place, so the timestamp updates and the PR conversation always
+  # renders the report at the bottom (after every commit).
+  behavior: new
+
+ignore:
+  - "tests/**"


### PR DESCRIPTION
Runs the test suite inside the LSST scipipe ``w_latest`` container on every PR and push to main, then uploads the resulting coverage.xml to Codecov so PRs surface coverage deltas.